### PR TITLE
Add a config option for disabling swiping

### DIFF
--- a/dist/Card.js
+++ b/dist/Card.js
@@ -124,124 +124,127 @@ angular.module(modName, ['ngTouch']).factory(modName, ['$swipe', '$q', function 
 
       throwOutDistance = config.throwOutDistance(config.minThrowOutDistance, config.maxThrowOutDistance);
 
-      $swipe.bind(angular.element(targetElement), {
-        'start': function start(coords) {
-          startCoords = coords;
-          isPanning = true;
-        },
-        'move': function move(coords) {
-          var deltaCoords = {
-            x: coords.x - startCoords.x,
-            y: coords.y - startCoords.y
-          };
-          eventEmitter.trigger('panmove', deltaCoords);
-        },
-        'end': function end(coords) {
-          isPanning = false;
-          var deltaCoords = {
-            x: coords.x - startCoords.x,
-            y: coords.y - startCoords.y
-          };
-          eventEmitter.trigger('panend', deltaCoords);
-        }
-      });
+      // If swiping is enabled, setup click/touch listeners
+      if (config.enableSwiping) {
+        $swipe.bind(angular.element(targetElement), {
+          'start': function start(coords) {
+            startCoords = coords;
+            isPanning = true;
+          },
+          'move': function move(coords) {
+            var deltaCoords = {
+              x: coords.x - startCoords.x,
+              y: coords.y - startCoords.y
+            };
+            eventEmitter.trigger('panmove', deltaCoords);
+          },
+          'end': function end(coords) {
+            isPanning = false;
+            var deltaCoords = {
+              x: coords.x - startCoords.x,
+              y: coords.y - startCoords.y
+            };
+            eventEmitter.trigger('panend', deltaCoords);
+          }
+        });
 
-      Card.appendToParent(targetElement);
-
-      eventEmitter.on('panstart', function () {
         Card.appendToParent(targetElement);
-        eventEmitter.trigger('dragstart', {
-          target: targetElement
+
+        eventEmitter.on('panstart', function () {
+          Card.appendToParent(targetElement);
+          eventEmitter.trigger('dragstart', {
+            target: targetElement
+          });
+
+          currentX = 0;
+          currentY = 0;
+
+          isDragging = true;
+
+          (function animation() {
+            if (isDragging) {
+              doMove();
+
+              window.requestAnimationFrame(animation);
+            }
+          })();
         });
 
-        currentX = 0;
-        currentY = 0;
+        eventEmitter.on('panmove', function (coords) {
+          currentX = coords.x;
+          currentY = coords.y;
+        });
 
-        isDragging = true;
+        eventEmitter.on('panend', function (coords) {
+          isDragging = false;
 
-        (function animation() {
-          if (isDragging) {
-            doMove();
+          var coordinateX = lastTranslate.coordinateX + coords.x;
+          var coordinateY = lastTranslate.coordinateY + coords.y;
 
-            window.requestAnimationFrame(animation);
+          var isThrowOut = config.isThrowOut(coordinateX, coordinateY, targetElement, config.throwOutConfidence(coordinateX, coordinateY, targetElement));
+
+          // Not really sure about computing direction here and filtering on directions here.
+          // It adds more logic. Any suggestion will be appreciated.
+          var direction = computeDirection(coordinateX, coordinateY, config.allowedDirections);
+
+          if (isThrowOut && direction !== _Direction2.default.INVALID) {
+            card.throwOut(coordinateX, coordinateY, direction);
+          } else {
+            card.throwIn(coordinateX, coordinateY, direction);
           }
-        })();
-      });
 
-      eventEmitter.on('panmove', function (coords) {
-        currentX = coords.x;
-        currentY = coords.y;
-      });
-
-      eventEmitter.on('panend', function (coords) {
-        isDragging = false;
-
-        var coordinateX = lastTranslate.coordinateX + coords.x;
-        var coordinateY = lastTranslate.coordinateY + coords.y;
-
-        var isThrowOut = config.isThrowOut(coordinateX, coordinateY, targetElement, config.throwOutConfidence(coordinateX, coordinateY, targetElement));
-
-        // Not really sure about computing direction here and filtering on directions here.
-        // It adds more logic. Any suggestion will be appreciated.
-        var direction = computeDirection(coordinateX, coordinateY, config.allowedDirections);
-
-        if (isThrowOut && direction !== _Direction2.default.INVALID) {
-          card.throwOut(coordinateX, coordinateY, direction);
-        } else {
-          card.throwIn(coordinateX, coordinateY, direction);
-        }
-
-        eventEmitter.trigger('dragend', {
-          target: targetElement
-        });
-      });
-
-      // "mousedown" event fires late on touch enabled devices, thus listening
-      // to the touchstart event for touch enabled devices and mousedown otherwise.
-      if ((0, _utilities.isTouchDevice)()) {
-        targetElement.addEventListener('touchstart', function () {
-          eventEmitter.trigger('panstart');
+          eventEmitter.trigger('dragend', {
+            target: targetElement
+          });
         });
 
-        targetElement.addEventListener('touchend', function () {
-          if (isDragging && !isPanning) {
-            eventEmitter.trigger('dragend', {
-              target: targetElement
-            });
-          }
-        });
-
-        // Disable scrolling while dragging the element on the touch enabled devices.
-        // @see http://stackoverflow.com/a/12090055/368691
-        (function () {
-          var dragging = void 0;
-
-          targetElement.addEventListener('touchstart', function (event) {
-            dragging = true;
+        // "mousedown" event fires late on touch enabled devices, thus listening
+        // to the touchstart event for touch enabled devices and mousedown otherwise.
+        if ((0, _utilities.isTouchDevice)()) {
+          targetElement.addEventListener('touchstart', function () {
+            eventEmitter.trigger('panstart');
           });
 
           targetElement.addEventListener('touchend', function () {
-            dragging = false;
+            if (isDragging && !isPanning) {
+              eventEmitter.trigger('dragend', {
+                target: targetElement
+              });
+            }
           });
 
-          global.addEventListener('touchmove', function (event) {
-            if (dragging) {
-              event.preventDefault();
-            }
-          }, supportPassive ? { passive: false } : false);
-        })();
-      } else {
-        targetElement.addEventListener('mousedown', function () {
-          eventEmitter.trigger('panstart');
-        });
+          // Disable scrolling while dragging the element on the touch enabled devices.
+          // @see http://stackoverflow.com/a/12090055/368691
+          (function () {
+            var dragging = void 0;
 
-        targetElement.addEventListener('mouseup', function () {
-          if (isDragging && !isPanning) {
-            eventEmitter.trigger('dragend', {
-              target: targetElement
+            targetElement.addEventListener('touchstart', function (event) {
+              dragging = true;
             });
-          }
-        });
+
+            targetElement.addEventListener('touchend', function () {
+              dragging = false;
+            });
+
+            global.addEventListener('touchmove', function (event) {
+              if (dragging) {
+                event.preventDefault();
+              }
+            }, supportPassive ? { passive: false } : false);
+          })();
+        } else {
+          targetElement.addEventListener('mousedown', function () {
+            eventEmitter.trigger('panstart');
+          });
+
+          targetElement.addEventListener('mouseup', function () {
+            if (isDragging && !isPanning) {
+              eventEmitter.trigger('dragend', {
+                target: targetElement
+              });
+            }
+          });
+        }
       }
 
       springThrowIn.addListener({
@@ -478,7 +481,8 @@ angular.module(modName, ['ngTouch']).factory(modName, ['$swipe', '$q', function 
       rotation: Card.rotation,
       throwOutConfidence: Card.throwOutConfidence,
       throwOutDistance: Card.throwOutDistance,
-      transform: Card.transform
+      transform: Card.transform,
+      enableSwiping: true
     };
 
     return (0, _utilities.assign)({}, defaultConfig, config);


### PR DESCRIPTION
Allows you to still throw a card left or right via the throwOut(direction) method.  This will be used when not on a mobile device.

Add `?w=1` to the end of this github url to make the diff readable 😛 